### PR TITLE
Add animation setup and player spawn control

### DIFF
--- a/ReplicatedStorage/Animations/Anim_Attack.lua
+++ b/ReplicatedStorage/Animations/Anim_Attack.lua
@@ -1,3 +1,3 @@
 local anim = Instance.new('Animation')
-anim.AnimationId = 'rbxassetid://0'
+anim.AnimationId = 'rbxassetid://507776043'
 return anim

--- a/ReplicatedStorage/Animations/Anim_Attack.lua
+++ b/ReplicatedStorage/Animations/Anim_Attack.lua
@@ -1,0 +1,3 @@
+local anim = Instance.new('Animation')
+anim.AnimationId = 'rbxassetid://0'
+return anim

--- a/ReplicatedStorage/Animations/Anim_Death.lua
+++ b/ReplicatedStorage/Animations/Anim_Death.lua
@@ -1,0 +1,3 @@
+local anim = Instance.new('Animation')
+anim.AnimationId = 'rbxassetid://0'
+return anim

--- a/ReplicatedStorage/Animations/Anim_Death.lua
+++ b/ReplicatedStorage/Animations/Anim_Death.lua
@@ -1,3 +1,3 @@
 local anim = Instance.new('Animation')
-anim.AnimationId = 'rbxassetid://0'
+anim.AnimationId = 'rbxassetid://507771019'
 return anim

--- a/ReplicatedStorage/Animations/Anim_TowerFire.lua
+++ b/ReplicatedStorage/Animations/Anim_TowerFire.lua
@@ -1,3 +1,3 @@
 local anim = Instance.new('Animation')
-anim.AnimationId = 'rbxassetid://0'
+anim.AnimationId = 'rbxassetid://5200585345'
 return anim

--- a/ReplicatedStorage/Animations/Anim_TowerFire.lua
+++ b/ReplicatedStorage/Animations/Anim_TowerFire.lua
@@ -1,0 +1,3 @@
+local anim = Instance.new('Animation')
+anim.AnimationId = 'rbxassetid://0'
+return anim

--- a/ReplicatedStorage/Animations/Anim_Walk.lua
+++ b/ReplicatedStorage/Animations/Anim_Walk.lua
@@ -1,3 +1,3 @@
 local anim = Instance.new('Animation')
-anim.AnimationId = 'rbxassetid://0'
+anim.AnimationId = 'rbxassetid://507767968'
 return anim

--- a/ReplicatedStorage/Animations/Anim_Walk.lua
+++ b/ReplicatedStorage/Animations/Anim_Walk.lua
@@ -1,0 +1,3 @@
+local anim = Instance.new('Animation')
+anim.AnimationId = 'rbxassetid://0'
+return anim

--- a/ReplicatedStorage/Modules/mod_Locale.lua
+++ b/ReplicatedStorage/Modules/mod_Locale.lua
@@ -3,7 +3,13 @@ local Locale = {}
 
 Locale.en = {
     shop = 'Shop',
-    play = 'Play'
+    play = 'Play',
+    level = 'Level',
+    wave = 'Wave',
+    day = 'Day',
+    night = 'Night',
+    coins = 'Coins',
+    inventory = 'Inventory'
 }
 
 return Locale

--- a/ServerScriptService/Core/srv_AnimationSetup.lua
+++ b/ServerScriptService/Core/srv_AnimationSetup.lua
@@ -1,0 +1,14 @@
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local folder = ReplicatedStorage:FindFirstChild('Animations')
+if folder then
+    for _, module in ipairs(folder:GetChildren()) do
+        if module:IsA('ModuleScript') then
+            local ok, anim = pcall(require, module)
+            if ok and typeof(anim) == 'Instance' then
+                anim.Name = module.Name
+                anim.Parent = folder
+            end
+        end
+    end
+end
+return {}

--- a/ServerScriptService/Core/srv_AnimationSetup.lua
+++ b/ServerScriptService/Core/srv_AnimationSetup.lua
@@ -7,6 +7,7 @@ if folder then
             if ok and typeof(anim) == 'Instance' then
                 anim.Name = module.Name
                 anim.Parent = folder
+                module:Destroy()
             end
         end
     end

--- a/ServerScriptService/Core/srv_AnimationSetup.lua
+++ b/ServerScriptService/Core/srv_AnimationSetup.lua
@@ -1,4 +1,5 @@
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local AnimationUtil = require(game.ServerScriptService.Modules.mod_AnimationUtil)
 local folder = ReplicatedStorage:FindFirstChild('Animations')
 if folder then
     for _, module in ipairs(folder:GetChildren()) do
@@ -12,4 +13,6 @@ if folder then
         end
     end
 end
+
+AnimationUtil.preloadAll()
 return {}

--- a/ServerScriptService/Core/srv_DownSystem.lua
+++ b/ServerScriptService/Core/srv_DownSystem.lua
@@ -1,4 +1,5 @@
 local Players = game:GetService('Players')
+Players.CharacterAutoLoads = false
 local Config = require(game:GetService('ReplicatedStorage').Modules.mod_Config)
 local Remotes = game:GetService('ReplicatedStorage'):WaitForChild('Remotes')
 local RE_RequestRevive = Remotes:WaitForChild('RE_RequestRevive')
@@ -20,6 +21,7 @@ local function onCharacterAdded(player, char)
 end
 
 Players.PlayerAdded:Connect(function(plr)
+    plr:LoadCharacter()
     plr.CharacterAdded:Connect(function(char)
         onCharacterAdded(plr, char)
     end)

--- a/ServerScriptService/Modules/mod_AnimationUtil.lua
+++ b/ServerScriptService/Modules/mod_AnimationUtil.lua
@@ -1,4 +1,5 @@
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local ContentProvider = game:GetService('ContentProvider')
 local Animations = ReplicatedStorage:WaitForChild('Animations')
 
 local util = {}
@@ -22,6 +23,27 @@ end
 function util.stop(track)
     if track and track.IsPlaying then
         track:Stop()
+    end
+end
+
+-- Preloads a single animation by id to avoid hitches on first play
+function util.preload(id)
+    local anim = util.load(id)
+    if anim then
+        ContentProvider:PreloadAsync({anim})
+        return true
+    end
+    return false
+end
+
+-- Preloads all animations in the folder
+function util.preloadAll()
+    local assets = {}
+    for _, child in ipairs(Animations:GetChildren()) do
+        table.insert(assets, child)
+    end
+    if #assets > 0 then
+        ContentProvider:PreloadAsync(assets)
     end
 end
 

--- a/ServerScriptService/Modules/mod_AnimationUtil.lua
+++ b/ServerScriptService/Modules/mod_AnimationUtil.lua
@@ -3,10 +3,25 @@ local Animations = ReplicatedStorage:WaitForChild('Animations')
 
 local util = {}
 
+-- Retrieves an animation instance by name
 function util.load(id)
-    local anim = Animations:FindFirstChild(id)
-    if anim then
-        return anim
+    return Animations:FindFirstChild(id)
+end
+
+-- Plays an animation on a humanoid and returns the track
+function util.play(id, humanoid)
+    local anim = util.load(id)
+    if anim and humanoid then
+        local track = humanoid:LoadAnimation(anim)
+        track:Play()
+        return track
+    end
+end
+
+-- Stops a given animation track if it is playing
+function util.stop(track)
+    if track and track.IsPlaying then
+        track:Stop()
     end
 end
 


### PR DESCRIPTION
## Summary
- add animation loader to convert module scripts into Animation instances
- expand animation utility with play/stop helpers
- disable automatic character spawning to support down system
- extend locale table with common HUD strings
- add placeholder animation assets

## Testing
- `luarocks install luacheck --local`
- `~/.luarocks/bin/luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_68906bcf98dc8330bce3c123b1c6c1cd