### PR TITLE
chore: add audit and build reports

### DIFF
--- a/AuditReport.md
+++ b/AuditReport.md
@@ -1,0 +1,22 @@
+# Audit Report
+
+| Nr. | Feature | Status | Pfad/Kommentar |
+| --- | ------- | ------ | -------------- |
+| 1 | Kristall: Platzieren, zerstören → Buff, Ersatz-Kristall, Game Over erst bei Kristall + alle Spieler tot | ✅ | ServerScriptService/Core/srv_CrystalHandler.lua |
+| 2 | Tag-/Nacht-System, Wellen nur nachts, Boss alle 10 Wellen | ✅ | ServerScriptService/Core/srv_GameLoop.lua, srv_WaveManager.lua |
+| 3 | Easy/Normal/Hard: Gegner + XP ±50% | ✅ | ReplicatedStorage/Modules/mod_Config.lua, ServerScriptService/Modules/mod_Utilities.lua |
+| 4 | Tower-Bau: Ghost, Coin-Kosten, Tower-Limit (3 + Level) | ❌ | TODO: Ghost-Visualisierung unvollständig (StarterPlayer/StarterPlayerScripts/cli_UIManager.lua) |
+| 5 | Coins durch Loot, XP durch Kills, Tower-Limit ↑ bei Level-Up | ✅ | ServerScriptService/Core/srv_LootHandler.lua, Modules/mod_LevelService.lua |
+| 6 | Down/Revive-System: 60 Sek. Down, 15 Sek. Heal | ✅ | ServerScriptService/Core/srv_DownSystem.lua |
+| 7 | Buyback beim Bürgermeister für 10.000 Coins | ❌ | TODO: Config.BuybackPrice in ReplicatedStorage/Modules/mod_Config.lua |
+| 8 | 3 Speicher-Slots (nur Host) | ✅ | ServerScriptService/Core/srv_SaveService.lua |
+| 9 | Lobby: Slot- & Schwierigkeits-GUI, Start durch Host, max. 6 Spieler | ❌ | TODO: Slot-GUI/Host-Start (StarterGui/ScreenGui_Menu/ls_Menu.lua) |
+| 10 | Sicherheitsprüfung aller Remotes, Aufräumroutinen | ✅ | ServerScriptService/Core/srv_AntiExploit.lua |
+| 11 | Ordnerstruktur vollständig | ✅ | Projektstruktur vorhanden |
+| 12 | Config.Version = v1.0.0 | ❌ | TODO: Version in ReplicatedStorage/Modules/mod_Config.lua |
+| 13 | BuildReport mit „ALLE 10 KRITERIEN ERFÜLLT“ & „Tests A–E PASS“ | ❌ | BuildReport.txt fehlt geforderte Inhalte |
+| 14 | Linter (Luau) läuft ohne Fehler (mit type stubs) | ❌ | `luau-lint` nicht installiert |
+| 15 | Headless-TestEZ-Tests vorhanden oder als SKIP markiert | ❌ | Keine Tests gefunden |
+
+## Ergebnis
+Nicht alle Kriterien erfüllt.

--- a/BuildReport.txt
+++ b/BuildReport.txt
@@ -1,0 +1,5 @@
+Test A: FAIL - kein Test implementiert
+Test B: FAIL - kein Test implementiert
+Test C: FAIL - kein Test implementiert
+Test D: FAIL - kein Test implementiert
+Test E: FAIL - kein Test implementiert

--- a/ReplicatedStorage/Modules/mod_Config.lua
+++ b/ReplicatedStorage/Modules/mod_Config.lua
@@ -1,6 +1,9 @@
 -- Shared configuration constants
 local Config = {}
 
+-- TODO: set final release version to v1.0.0
+Config.Version = "0.0.0"
+
 Config.Difficulty = "Normal" -- Easy, Normal, Hard
 Config.DifficultyModifiers = {
     -- difficulty multipliers applied to monster stats and XP gains
@@ -58,6 +61,7 @@ Config.MaxPlayers = 6
 
 Config.StartWeapon = 'Hands'
 Config.StartAmmo = 0
+-- TODO: adjust buyback price to 10000 coins per specification
 Config.BuybackPrice = 10
 
 return Config

--- a/StarterGui/ScreenGui_Menu/ls_Menu.lua
+++ b/StarterGui/ScreenGui_Menu/ls_Menu.lua
@@ -4,6 +4,8 @@ local RE_PlayerSpawnRequest = remotes:WaitForChild('RE_PlayerSpawnRequest')
 local RE_SetDifficulty = remotes:WaitForChild('RE_SetDifficulty')
 local RE_GameOver = remotes:WaitForChild('RE_GameOver')
 
+-- TODO: implement save slot selection and host-controlled lobby start for up to 6 players
+
 local gui = script.Parent
 local playButton = gui:WaitForChild('PlayButton')
 


### PR DESCRIPTION
## Summary
- add version and buyback TODOs in config
- note missing lobby slot selection via TODO
- add audit and build reports summarizing system gaps

## Testing
- `luau-lint .` *(fails: command not found)*
- `npx testez` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891edc9af0083309152fb51bfac65b8