### PR TITLE
Add battlegrounds server framework and setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,28 @@
-# Welcome to GitHub Desktop!
+# Battlegrounds Roblox Server Kit
 
-This is your README. READMEs are where you can communicate what your project is and how to use it.
+Dieses Repository enthält ein vollständiges, serverseitiges Battlegrounds-Grundgerüst für Roblox. Es richtet eine Rundenlogik, ein simples Nahkampf-System, Spawn-Handling und Leaderstats ein.
 
-Write your name on line 6, save it, and then head back to GitHub Desktop.
+## Features
+- Runden- & Intermission-Loop mit Score-to-Win
+- Nahkampf-Hitbox mit Knockback
+- Leaderstats (KOs, WOs, Streak, Score)
+- Randomisierte Spawns
+- RemoteEvent für Attacken & Rundenzustand
+
+## Struktur
+- `ServerScriptService/Main.server.lua`: Haupt-Loop, Round-Management, RemoteEvents
+- `ServerScriptService/Modules/*.lua`: Konfiguration, Player-, Combat-, Match- und Spawn-Services
+
+## Setup in Roblox Studio
+1. Erstelle in **Workspace** einen Ordner `Arena`.
+2. Lege in `Arena` einen Ordner `Spawns` an und platziere darin SpawnParts.
+3. Kopiere die Ordnerstruktur dieses Repos in dein Roblox-Spiel:
+   - `ServerScriptService` nach **ServerScriptService**
+   - `ReplicatedStorage/Remotes` nach **ReplicatedStorage** (die Remotes werden zur Not auch serverseitig erzeugt).
+4. Starte das Spiel und löse Client-seitig das `Attack`-RemoteEvent aus (z. B. über ein Tool oder Input-Script).
+
+## Client-Hinweis
+Das Server-Script erwartet einen Client, der bei einem Angriff `Remotes.Attack:FireServer()` aufruft. Außerdem kannst du den Rundenzustand über `Remotes.RoundState.OnClientEvent` anzeigen (HUD).
+
+## Konfiguration
+Alle Einstellungen befinden sich in `ServerScriptService/Modules/Config.lua`.

--- a/ServerScriptService/Main.server.lua
+++ b/ServerScriptService/Main.server.lua
@@ -1,0 +1,134 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+
+local Config = require(script.Modules.Config)
+local PlayerService = require(script.Modules.PlayerService)
+local CombatService = require(script.Modules.CombatService)
+local SpawnService = require(script.Modules.SpawnService)
+local MatchService = require(script.Modules.MatchService)
+
+local remotesFolder = ReplicatedStorage:FindFirstChild("Remotes")
+if not remotesFolder then
+    remotesFolder = Instance.new("Folder")
+    remotesFolder.Name = "Remotes"
+    remotesFolder.Parent = ReplicatedStorage
+end
+
+local attackEvent = remotesFolder:FindFirstChild("Attack")
+if not attackEvent then
+    attackEvent = Instance.new("RemoteEvent")
+    attackEvent.Name = "Attack"
+    attackEvent.Parent = remotesFolder
+end
+
+local roundEvent = remotesFolder:FindFirstChild("RoundState")
+if not roundEvent then
+    roundEvent = Instance.new("RemoteEvent")
+    roundEvent.Name = "RoundState"
+    roundEvent.Parent = remotesFolder
+end
+
+local combatService = CombatService.new(Config)
+local spawnService = SpawnService.new(Config)
+local matchService = MatchService.new(Config, PlayerService, spawnService)
+
+local profiles = {}
+
+local function broadcastRoundState()
+    roundEvent:FireAllClients({
+        State = matchService.State,
+        TimeRemaining = math.max(0, math.floor(matchService.TimeRemaining)),
+    })
+end
+
+local function registerPlayer(player)
+    local profile = PlayerService.createProfile(player, Config.Stats.Default)
+    profiles[player] = profile
+    matchService:registerPlayer(profile)
+
+    player.CharacterAdded:Connect(function(character)
+        local humanoid = character:WaitForChild("Humanoid")
+        profile.Alive = true
+        profile.Lives = Config.Game.MaxLives
+        humanoid.Died:Connect(function()
+            profile.Alive = false
+            PlayerService.applyWO(profile)
+        end)
+    end)
+
+    player:LoadCharacter()
+end
+
+local function unregisterPlayer(player)
+    profiles[player] = nil
+    matchService:unregisterPlayer(player)
+end
+
+Players.PlayerAdded:Connect(registerPlayer)
+Players.PlayerRemoving:Connect(unregisterPlayer)
+
+attackEvent.OnServerEvent:Connect(function(player)
+    local profile = profiles[player]
+    if not profile or not profile.Alive then
+        return
+    end
+
+    if not combatService:canAttack(player) then
+        return
+    end
+
+    combatService:markAttack(player)
+
+    for _, target in ipairs(combatService:getTargets(player)) do
+        combatService:applyDamage(player, target.Humanoid)
+        profile.LastHitTime = os.clock()
+        profile.LastAttacker = player
+        if target.Humanoid.Health - Config.Combat.BaseDamage <= 0 then
+            PlayerService.applyKO(profile)
+        end
+    end
+end)
+
+matchService:startIntermission()
+
+local lastTick = os.clock()
+RunService.Heartbeat:Connect(function()
+    local now = os.clock()
+    local dt = now - lastTick
+    lastTick = now
+
+    if matchService:tick(dt) then
+        if matchService.State == "Intermission" then
+            if #Players:GetPlayers() >= Config.Game.MinPlayersToStart then
+                matchService:resetRound()
+                matchService:spawnAll()
+            else
+                matchService:startIntermission()
+            end
+        else
+            local winner = matchService:checkWinner()
+            if winner then
+                local winnerProfile = profiles[winner]
+                if winnerProfile then
+                    PlayerService.applyKO(winnerProfile)
+                end
+            end
+
+            for _, profile in pairs(profiles) do
+                PlayerService.resetRoundStats(profile)
+            end
+            matchService:startIntermission()
+        end
+        broadcastRoundState()
+    end
+end)
+
+Players.PlayerAdded:Connect(function(player)
+    roundEvent:FireClient(player, {
+        State = matchService.State,
+        TimeRemaining = math.max(0, math.floor(matchService.TimeRemaining)),
+    })
+end)
+
+broadcastRoundState()

--- a/ServerScriptService/Modules/CombatService.lua
+++ b/ServerScriptService/Modules/CombatService.lua
@@ -1,0 +1,82 @@
+local Players = game:GetService("Players")
+
+local CombatService = {}
+
+function CombatService.new(config)
+    local self = {
+        Config = config,
+        Cooldowns = {},
+    }
+
+    return setmetatable(self, { __index = CombatService })
+end
+
+local function isAlive(humanoid)
+    return humanoid and humanoid.Health > 0
+end
+
+function CombatService:canAttack(player)
+    local last = self.Cooldowns[player] or 0
+    return os.clock() - last >= self.Config.Combat.Cooldown
+end
+
+function CombatService:markAttack(player)
+    self.Cooldowns[player] = os.clock()
+end
+
+function CombatService:getTargets(attacker)
+    local character = attacker.Character
+    if not character then
+        return {}
+    end
+
+    local root = character:FindFirstChild("HumanoidRootPart")
+    if not root then
+        return {}
+    end
+
+    local hitbox = Instance.new("Part")
+    hitbox.Size = self.Config.Combat.HitboxSize
+    hitbox.CFrame = root.CFrame * self.Config.Combat.HitboxOffset
+    hitbox.Transparency = 1
+    hitbox.CanCollide = false
+    hitbox.Anchored = true
+    hitbox.Parent = workspace
+
+    local targets = {}
+    for _, part in ipairs(workspace:GetPartsInPart(hitbox)) do
+        local model = part:FindFirstAncestorOfClass("Model")
+        if model and model ~= character then
+            local humanoid = model:FindFirstChildOfClass("Humanoid")
+            local player = Players:GetPlayerFromCharacter(model)
+            if humanoid and player and isAlive(humanoid) then
+                targets[player] = humanoid
+            end
+        end
+    end
+
+    hitbox:Destroy()
+
+    local list = {}
+    for player, humanoid in pairs(targets) do
+        table.insert(list, { Player = player, Humanoid = humanoid })
+    end
+
+    return list
+end
+
+function CombatService:applyDamage(attacker, targetHumanoid)
+    targetHumanoid:TakeDamage(self.Config.Combat.BaseDamage)
+
+    local root = targetHumanoid.Parent:FindFirstChild("HumanoidRootPart")
+    if root then
+        local force = Instance.new("BodyVelocity")
+        force.Velocity = (root.Position - attacker.Character.HumanoidRootPart.Position).Unit
+            * self.Config.Combat.Knockback
+        force.MaxForce = Vector3.new(1e5, 1e5, 1e5)
+        force.Parent = root
+        game:GetService("Debris"):AddItem(force, 0.15)
+    end
+end
+
+return CombatService

--- a/ServerScriptService/Modules/Config.lua
+++ b/ServerScriptService/Modules/Config.lua
@@ -1,0 +1,34 @@
+local Config = {}
+
+Config.Game = {
+    RoundDuration = 180,
+    IntermissionDuration = 20,
+    MinPlayersToStart = 2,
+    MaxLives = 0,
+    ScoreToWin = 10,
+}
+
+Config.Combat = {
+    BaseDamage = 25,
+    Cooldown = 0.6,
+    Knockback = 40,
+    HitboxSize = Vector3.new(5, 5, 5),
+    HitboxOffset = CFrame.new(0, 0, -3),
+}
+
+Config.Spawn = {
+    SpawnFolderName = "Spawns",
+    ArenaFolderName = "Arena",
+    FallbackSpawn = Vector3.new(0, 6, 0),
+}
+
+Config.Stats = {
+    Default = {
+        KOs = 0,
+        WOs = 0,
+        Streak = 0,
+        Score = 0,
+    },
+}
+
+return Config

--- a/ServerScriptService/Modules/MatchService.lua
+++ b/ServerScriptService/Modules/MatchService.lua
@@ -1,0 +1,72 @@
+local MatchService = {}
+
+function MatchService.new(config, playerService, spawnService)
+    local self = {
+        Config = config,
+        PlayerService = playerService,
+        SpawnService = spawnService,
+        State = "Intermission",
+        TimeRemaining = 0,
+        ActivePlayers = {},
+        RoundWinners = {},
+    }
+
+    return setmetatable(self, { __index = MatchService })
+end
+
+function MatchService:resetRound()
+    self.ActivePlayers = {}
+    self.RoundWinners = {}
+    self.TimeRemaining = self.Config.Game.RoundDuration
+    self.State = "Round"
+end
+
+function MatchService:startIntermission()
+    self.State = "Intermission"
+    self.TimeRemaining = self.Config.Game.IntermissionDuration
+end
+
+function MatchService:registerPlayer(profile)
+    self.ActivePlayers[profile.Player] = profile
+end
+
+function MatchService:unregisterPlayer(player)
+    self.ActivePlayers[player] = nil
+end
+
+function MatchService:getAliveCount()
+    local count = 0
+    for _, profile in pairs(self.ActivePlayers) do
+        if profile.Alive then
+            count += 1
+        end
+    end
+    return count
+end
+
+function MatchService:checkWinner()
+    for _, profile in pairs(self.ActivePlayers) do
+        local leaderstats = profile.Player:FindFirstChild("leaderstats")
+        local score = leaderstats and leaderstats:FindFirstChild("Score")
+        if score and score.Value >= self.Config.Game.ScoreToWin then
+            return profile.Player
+        end
+    end
+    return nil
+end
+
+function MatchService:spawnAll()
+    for _, profile in pairs(self.ActivePlayers) do
+        self.SpawnService:spawnProfile(profile)
+    end
+end
+
+function MatchService:tick(dt)
+    self.TimeRemaining -= dt
+    if self.TimeRemaining <= 0 then
+        return true
+    end
+    return false
+end
+
+return MatchService

--- a/ServerScriptService/Modules/PlayerService.lua
+++ b/ServerScriptService/Modules/PlayerService.lua
@@ -1,0 +1,94 @@
+local Players = game:GetService("Players")
+
+local PlayerService = {}
+
+local function createLeaderstats(player, defaults)
+    local leaderstats = Instance.new("Folder")
+    leaderstats.Name = "leaderstats"
+    leaderstats.Parent = player
+
+    for statName, value in pairs(defaults) do
+        local stat = Instance.new("IntValue")
+        stat.Name = statName
+        stat.Value = value
+        stat.Parent = leaderstats
+    end
+
+    return leaderstats
+end
+
+function PlayerService.createProfile(player, defaults)
+    local profile = {
+        Player = player,
+        Alive = false,
+        Lives = 0,
+        LastHitTime = 0,
+        LastAttacker = nil,
+    }
+
+    createLeaderstats(player, defaults)
+    return profile
+end
+
+function PlayerService.applyKO(profile)
+    local leaderstats = profile.Player:FindFirstChild("leaderstats")
+    if leaderstats then
+        local kos = leaderstats:FindFirstChild("KOs")
+        if kos then
+            kos.Value += 1
+        end
+        local streak = leaderstats:FindFirstChild("Streak")
+        if streak then
+            streak.Value += 1
+        end
+        local score = leaderstats:FindFirstChild("Score")
+        if score then
+            score.Value += 1
+        end
+    end
+end
+
+function PlayerService.applyWO(profile)
+    local leaderstats = profile.Player:FindFirstChild("leaderstats")
+    if leaderstats then
+        local wos = leaderstats:FindFirstChild("WOs")
+        if wos then
+            wos.Value += 1
+        end
+        local streak = leaderstats:FindFirstChild("Streak")
+        if streak then
+            streak.Value = 0
+        end
+    end
+end
+
+function PlayerService.resetRoundStats(profile)
+    local leaderstats = profile.Player:FindFirstChild("leaderstats")
+    if leaderstats then
+        local streak = leaderstats:FindFirstChild("Streak")
+        if streak then
+            streak.Value = 0
+        end
+    end
+end
+
+function PlayerService.resetAllStats(player, defaults)
+    local leaderstats = player:FindFirstChild("leaderstats")
+    if leaderstats then
+        for statName, value in pairs(defaults) do
+            local stat = leaderstats:FindFirstChild(statName)
+            if stat then
+                stat.Value = value
+            end
+        end
+    end
+end
+
+Players.PlayerRemoving:Connect(function(player)
+    local leaderstats = player:FindFirstChild("leaderstats")
+    if leaderstats then
+        leaderstats:Destroy()
+    end
+end)
+
+return PlayerService

--- a/ServerScriptService/Modules/SpawnService.lua
+++ b/ServerScriptService/Modules/SpawnService.lua
@@ -1,0 +1,55 @@
+local SpawnService = {}
+
+function SpawnService.new(config)
+    local self = {
+        Config = config,
+    }
+
+    return setmetatable(self, { __index = SpawnService })
+end
+
+function SpawnService:getSpawnPoints()
+    local arena = workspace:FindFirstChild(self.Config.Spawn.ArenaFolderName)
+    if not arena then
+        return {}
+    end
+    local folder = arena:FindFirstChild(self.Config.Spawn.SpawnFolderName)
+    if not folder then
+        return {}
+    end
+    return folder:GetChildren()
+end
+
+function SpawnService:getRandomSpawn()
+    local spawns = self:getSpawnPoints()
+    if #spawns == 0 then
+        return nil
+    end
+    return spawns[math.random(1, #spawns)]
+end
+
+function SpawnService:spawnProfile(profile)
+    local player = profile.Player
+    if not player.Character then
+        player:LoadCharacter()
+    end
+
+    local character = player.Character
+    local root = character:FindFirstChild("HumanoidRootPart")
+    local humanoid = character:FindFirstChildOfClass("Humanoid")
+    if not root or not humanoid then
+        return
+    end
+
+    local spawnPoint = self:getRandomSpawn()
+    if spawnPoint then
+        root.CFrame = spawnPoint.CFrame + Vector3.new(0, 3, 0)
+    else
+        root.CFrame = CFrame.new(self.Config.Spawn.FallbackSpawn)
+    end
+
+    humanoid.Health = humanoid.MaxHealth
+    profile.Alive = true
+end
+
+return SpawnService


### PR DESCRIPTION
### Motivation
- Provide a complete server-side Battlegrounds foundation for Roblox with round management, combat, spawns and player stats.
- Make the game logic modular so different systems (combat, spawn, match, player) can be extended or swapped easily.
- Expose simple RemoteEvents so clients can trigger attacks and receive round state for HUDs.

### Description
- Add `ServerScriptService/Main.server.lua` implementing the main loop, round/intermission flow, player registration, and server-side `Attack` and `RoundState` RemoteEvents. 
- Add modular services: `ServerScriptService/Modules/CombatService.lua`, `PlayerService.lua`, `MatchService.lua`, and `SpawnService.lua` to handle combat hitboxes/knockback, leaderstats/profiles, match lifecycle, and spawning respectively. 
- Add `ServerScriptService/Modules/Config.lua` to centralize gameplay settings such as `RoundDuration`, `ScoreToWin`, `Combat.BaseDamage`, and spawn folder names. 
- Add README with setup instructions for Roblox Studio and notes about expected client behavior (use `Remotes.Attack:FireServer()` and `Remotes.RoundState.OnClientEvent`).

### Testing
- No automated tests were run against the new code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967e8104ac88330aa0a158dbd798081)