### PR TITLE
Add Roblox combat system modules and scripts

### DIFF
--- a/ReplicatedStorage/Modules/CombatConfig.lua
+++ b/ReplicatedStorage/Modules/CombatConfig.lua
@@ -1,0 +1,17 @@
+local CombatConfig = {}
+
+CombatConfig.FISTS = {
+	[1] = {name="JabCombo", cooldown=0.6, damage=8, stun=0.2, knockback=25, range=4, size=Vector3.new(5,5,6)},
+	[2] = {name="Uppercut", cooldown=4, damage=18, stun=0.6, knockback=45, range=4, size=Vector3.new(5,6,6)},
+	[3] = {name="GroundSlam", cooldown=6, damage=22, stun=0.8, knockback=30, radius=8},
+	[4] = {name="DashPunch", cooldown=5, damage=16, stun=0.5, knockback=50, range=6, size=Vector3.new(6,5,8), dashSpeed=60, dashTime=0.25},
+}
+
+CombatConfig.SWORD = {
+	[1] = {name="SlashCombo", cooldown=0.8, damage=10, stun=0.2, knockback=28, range=5, size=Vector3.new(6,5,8)},
+	[2] = {name="WhirlwindSpin", cooldown=7, damage=20, stun=0.6, knockback=35, radius=9},
+	[3] = {name="DashStrike", cooldown=5, damage=18, stun=0.4, knockback=50, range=7, size=Vector3.new(6,5,9), dashSpeed=70, dashTime=0.2},
+	[4] = {name="BladeWave", cooldown=8, damage=16, stun=0.4, knockback=40, projectileSpeed=70, projectileRange=60, projectileRadius=4},
+}
+
+return CombatConfig

--- a/ReplicatedStorage/Modules/CombatService.lua
+++ b/ReplicatedStorage/Modules/CombatService.lua
@@ -1,0 +1,195 @@
+local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
+
+local CombatConfig = require(script.Parent.CombatConfig)
+local Hitbox = require(script.Parent.Hitbox)
+local StunService = require(script.Parent.StunService)
+
+local CombatService = {}
+
+local cooldowns = {} -- cooldowns[player][weaponType][skill] = lastUseTime
+
+local function isAlive(character)
+	local humanoid = character and character:FindFirstChildOfClass("Humanoid")
+	return humanoid and humanoid.Health > 0
+end
+
+local function getRoot(character)
+	return character and character:FindFirstChild("HumanoidRootPart")
+end
+
+local function getWeaponType(player)
+	local wt = player:GetAttribute("WeaponType")
+	if wt ~= "Sword" then
+		return "Fists"
+	end
+	return "Sword"
+end
+
+local function canUseSkill(player, character)
+	if not player or not character then return false end
+	if not isAlive(character) then return false end
+	if StunService:IsStunned(character) then return false end
+	return true
+end
+
+local function getSkillConfig(weaponType, skillId)
+	if weaponType == "Sword" then
+		return CombatConfig.SWORD[skillId]
+	end
+	return CombatConfig.FISTS[skillId]
+end
+
+local function getCooldownTable(player, weaponType)
+	cooldowns[player] = cooldowns[player] or {}
+	cooldowns[player][weaponType] = cooldowns[player][weaponType] or {}
+	return cooldowns[player][weaponType]
+end
+
+local function onCooldown(player, weaponType, skillId, cooldown)
+	local now = os.clock()
+	local tbl = getCooldownTable(player, weaponType)
+	local last = tbl[skillId] or 0
+	return (now - last) < cooldown
+end
+
+local function setCooldown(player, weaponType, skillId)
+	local tbl = getCooldownTable(player, weaponType)
+	tbl[skillId] = os.clock()
+end
+
+local function applyDamageAndKnockback(attacker, targets, damage, knockback)
+	for _, character in ipairs(targets) do
+		if character ~= attacker and isAlive(character) then
+			local humanoid = character:FindFirstChildOfClass("Humanoid")
+			local root = getRoot(character)
+			if humanoid then
+				humanoid:TakeDamage(damage)
+				StunService:ApplyStun(character, math.max(0.1, 0))
+			end
+			if root and knockback and knockback > 0 then
+				local dir = (root.Position - getRoot(attacker).Position).Unit
+				root.AssemblyLinearVelocity = dir * knockback
+			end
+		end
+	end
+end
+
+local function overlapParamsFor(attacker)
+	local params = OverlapParams.new()
+	params.FilterType = Enum.RaycastFilterType.Exclude
+	params.FilterDescendantsInstances = {attacker}
+	return params
+end
+
+local function doMeleeBox(attacker, config)
+	local root = getRoot(attacker)
+	if not root then return end
+	local cframe = root.CFrame * CFrame.new(0, 0, -config.range)
+	local targets = Hitbox.Box(cframe, config.size, overlapParamsFor(attacker))
+	return targets
+end
+
+local function doRadius(attacker, radius)
+	local root = getRoot(attacker)
+	if not root then return end
+	local targets = Hitbox.Radius(root.Position, radius, overlapParamsFor(attacker))
+	return targets
+end
+
+local function dashForward(character, speed, time)
+	local root = getRoot(character)
+	if not root then return end
+	local dir = root.CFrame.LookVector
+	root.AssemblyLinearVelocity = dir * speed
+	task.delay(time, function()
+		if root then
+			root.AssemblyLinearVelocity = Vector3.new(0, root.AssemblyLinearVelocity.Y, 0)
+		end
+	end)
+end
+
+local function bladeWave(attacker, config)
+	local root = getRoot(attacker)
+	if not root then return end
+
+	local projectile = Instance.new("Part")
+	projectile.Name = "BladeWave"
+	projectile.Size = Vector3.new(1,1,1)
+	projectile.Shape = Enum.PartType.Ball
+	projectile.Anchored = true
+	projectile.CanCollide = false
+	projectile.Transparency = 0.5
+	projectile.Material = Enum.Material.Neon
+	projectile.Color = Color3.fromRGB(120, 170, 255)
+	projectile.CFrame = root.CFrame * CFrame.new(0, 1, -3)
+	projectile.Parent = workspace
+
+	local traveled = 0
+	local lastPos = projectile.Position
+	local con
+	con = RunService.Heartbeat:Connect(function(dt)
+		if not projectile or not projectile.Parent then
+			if con then con:Disconnect() end
+			return
+		end
+		local step = config.projectileSpeed * dt
+		traveled += step
+		projectile.CFrame = projectile.CFrame * CFrame.new(0, 0, -step)
+
+		local targets = Hitbox.Radius(projectile.Position, config.projectileRadius, overlapParamsFor(attacker))
+		applyDamageAndKnockback(attacker, targets, config.damage, config.knockback)
+		for _, ch in ipairs(targets) do
+			StunService:ApplyStun(ch, config.stun)
+		end
+
+		if traveled >= config.projectileRange then
+			projectile:Destroy()
+			if con then con:Disconnect() end
+		end
+		lastPos = projectile.Position
+	end)
+end
+
+function CombatService:ActivateSkill(player, skillId)
+	if typeof(skillId) ~= "number" then return end
+	local character = player.Character
+	if not canUseSkill(player, character) then return end
+
+	local weaponType = getWeaponType(player)
+	local config = getSkillConfig(weaponType, skillId)
+	if not config then return end
+
+	if weaponType == "Sword" and player:GetAttribute("WeaponType") ~= "Sword" then
+		return
+	end
+
+	if onCooldown(player, weaponType, skillId, config.cooldown) then return end
+	setCooldown(player, weaponType, skillId)
+
+	if config.dashSpeed then
+		dashForward(character, config.dashSpeed, config.dashTime or 0.2)
+	end
+
+	local targets = {}
+	if config.size then
+		targets = doMeleeBox(character, config) or {}
+	elseif config.radius then
+		targets = doRadius(character, config.radius) or {}
+	end
+
+	if config.name == "BladeWave" then
+		bladeWave(character, config)
+	else
+		applyDamageAndKnockback(character, targets, config.damage, config.knockback)
+		for _, ch in ipairs(targets) do
+			StunService:ApplyStun(ch, config.stun)
+		end
+	end
+end
+
+Players.PlayerRemoving:Connect(function(player)
+	cooldowns[player] = nil
+end)
+
+return CombatService

--- a/ReplicatedStorage/Modules/Hitbox.lua
+++ b/ReplicatedStorage/Modules/Hitbox.lua
@@ -1,0 +1,39 @@
+local Hitbox = {}
+
+local function getCharacterFromPart(part)
+	if not part then return nil end
+	local model = part:FindFirstAncestorOfClass("Model")
+	if not model then return nil end
+	local humanoid = model:FindFirstChildOfClass("Humanoid")
+	if humanoid and humanoid.Health > 0 then
+		return model
+	end
+	return nil
+end
+
+local function uniqueCharactersFromParts(parts)
+	local found = {}
+	for _, part in ipairs(parts) do
+		local character = getCharacterFromPart(part)
+		if character then
+			found[character] = true
+		end
+	end
+	local list = {}
+	for character in pairs(found) do
+		table.insert(list, character)
+	end
+	return list
+end
+
+function Hitbox.Box(cframe, size, overlapParams)
+	local parts = workspace:GetPartBoundsInBox(cframe, size, overlapParams)
+	return uniqueCharactersFromParts(parts)
+end
+
+function Hitbox.Radius(position, radius, overlapParams)
+	local parts = workspace:GetPartBoundsInRadius(position, radius, overlapParams)
+	return uniqueCharactersFromParts(parts)
+end
+
+return Hitbox

--- a/ReplicatedStorage/Modules/StunService.lua
+++ b/ReplicatedStorage/Modules/StunService.lua
@@ -1,0 +1,25 @@
+local StunService = {}
+
+local activeStuns = {}
+
+function StunService:IsStunned(character)
+	return character:GetAttribute("Stunned") == true
+end
+
+function StunService:ApplyStun(character, duration)
+	if not character or duration <= 0 then return end
+	local token = os.clock()
+	activeStuns[character] = token
+	character:SetAttribute("Stunned", true)
+
+	task.delay(duration, function()
+		if activeStuns[character] == token then
+			activeStuns[character] = nil
+			if character then
+				character:SetAttribute("Stunned", false)
+			end
+		end
+	end)
+end
+
+return StunService

--- a/ServerScriptService/CombatServer.lua
+++ b/ServerScriptService/CombatServer.lua
@@ -1,0 +1,8 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local CombatService = require(ReplicatedStorage.Modules.CombatService)
+local CombatEvent = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("CombatEvent")
+
+CombatEvent.OnServerEvent:Connect(function(player, skillId)
+	CombatService:ActivateSkill(player, skillId)
+end)

--- a/StarterPack/Sword/SwordScript.lua
+++ b/StarterPack/Sword/SwordScript.lua
@@ -1,0 +1,29 @@
+local tool = script.Parent
+local Players = game:GetService("Players")
+
+local function setWeaponType(character, value)
+	local player = Players:GetPlayerFromCharacter(character)
+	if player then
+		player:SetAttribute("WeaponType", value)
+	end
+end
+
+tool.Equipped:Connect(function()
+	local character = tool.Parent
+	setWeaponType(character, "Sword")
+end)
+
+tool.Unequipped:Connect(function()
+	local character = tool.Parent
+	setWeaponType(character, "Fists")
+end)
+
+tool.AncestryChanged:Connect(function()
+	local character = tool.Parent
+	if character and character:IsA("Model") then
+		local humanoid = character:FindFirstChildOfClass("Humanoid")
+		if humanoid then
+			setWeaponType(character, "Fists")
+		end
+	end
+end)

--- a/StarterPlayer/StarterPlayerScripts/CombatClient.lua
+++ b/StarterPlayer/StarterPlayerScripts/CombatClient.lua
@@ -1,0 +1,21 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ContextActionService = game:GetService("ContextActionService")
+
+local CombatEvent = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("CombatEvent")
+
+local function onSkill(actionName, inputState)
+	if inputState ~= Enum.UserInputState.Begin then
+		return Enum.ContextActionResult.Pass
+	end
+
+	local skillId = tonumber(actionName:match("Skill(%d)"))
+	if skillId then
+		CombatEvent:FireServer(skillId)
+	end
+	return Enum.ContextActionResult.Sink
+end
+
+ContextActionService:BindAction("Skill1", onSkill, false, Enum.KeyCode.Q)
+ContextActionService:BindAction("Skill2", onSkill, false, Enum.KeyCode.E)
+ContextActionService:BindAction("Skill3", onSkill, false, Enum.KeyCode.R)
+ContextActionService:BindAction("Skill4", onSkill, false, Enum.KeyCode.F)


### PR DESCRIPTION
### Motivation
- Provide a modular server-side combat system supporting distinct `FISTS` and `SWORD` skill sets with configurable parameters.
- Implement reliable hit detection and targeting utilities for melee boxes and radii.
- Add stun handling and cooldowns to prevent skill abuse and coordinate effects across characters.
- Wire client input and a tool to trigger server-side skill activation via a `RemoteEvent`.

### Description
- Added `ReplicatedStorage/Modules/CombatConfig.lua` containing skill definitions for fists and sword and their parameters.
- Added `ReplicatedStorage/Modules/Hitbox.lua` exposing `Box` and `Radius` functions that return unique character targets from overlap queries.  
- Added `ReplicatedStorage/Modules/StunService.lua` to manage stun tokens and a `Stunned` attribute on characters.  
- Added `ReplicatedStorage/Modules/CombatService.lua` implementing `CombatService:ActivateSkill`, cooldowns, hit application (`applyDamageAndKnockback`), dash behavior, and the `BladeWave` projectile.  
- Added `ServerScriptService/CombatServer.lua` to forward `CombatEvent.OnServerEvent` calls to `CombatService:ActivateSkill`.  
- Added `StarterPlayer/StarterPlayerScripts/CombatClient.lua` to bind `Q/E/R/F` to fire the `CombatEvent` with a skill id using `ContextActionService`.  
- Added `StarterPack/Sword/SwordScript.lua` to set the player's `WeaponType` attribute on equip/unequip and on ancestry changes.  
- Notes: the runtime expects a `RemoteEvent` at `ReplicatedStorage/Remotes/CombatEvent` to be created in the place hierarchy.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f9d350688330bf19475a38358eb9)